### PR TITLE
add path parameter to curl exec specification

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,7 @@ class kibana4 (
   # download/install kibana files
 
   exec { 'Download Kibana4':
+    path    => [ '/bin', '/usr/bin', '/usr/local/bin' ],
     command => "curl -s -L ${download_path}/kibana-${version}.tar.gz | tar xz",
     cwd     => $install_dir,
     creates => "${install_dir}/kibana-${version}",


### PR DESCRIPTION
I've added path parameter to exec specification to overcome issues with running with --noop where path is not defined yet.
eg:
# puppet apply --noop --modulepath=/opt/puppet/modules/ server_node.pp
Error: Validation of Exec[Download Kibana4] failed: 'curl -s -L http://download.elasticsearch.org/kibana/kibana/kibana-4.0.2-linux-x64.tar.gz | tar xz' is not qualified and no path was specified. Please qualify the command or specify a path. at /opt/puppet/modules/kibana4/manifests/init.pp:59
