### PR TITLE
Feature/runas

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Default: '' (empty string)
 
 Default: '/var/run/kibana.pid' (string)
 
+#####`log_file`
+
+Default: './kibana.log' (string)
+
 #####`bundled_plugin_ids`
 
 Enable or disable the appendonly file option. 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class kibana4 (
   $version            = '4.0.0-linux-x64',
   $download_path      = 'http://download.elasticsearch.org/kibana/kibana',
   $install_dir        = '/opt',
+  $log_file           = './kibana.log',
   $running            = true,
   $enabled            = true,
   $port               = 5601,

--- a/templates/etc/init.d/redhat.erb
+++ b/templates/etc/init.d/redhat.erb
@@ -23,6 +23,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 prog=kibana4
 DAEMON=<%= @install_dir %>/kibana4/bin/kibana
 DAEMON_ARGS=""
+KIBANA_USER="RUNASIS"
 pidfile=<%= @pid_file %>
 lockfile=/var/lock/subsys/$prog
 
@@ -31,10 +32,24 @@ lockfile=/var/lock/subsys/$prog
 [ -e /etc/default/$prog ] && . /etc/default/$prog
 [ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
 
+# For SELinux we need to use 'runuser' not 'su'
+if [ -x /sbin/runuser ]
+then
+    SU=runuser
+else
+    SU=su
+fi
+
+if [ "$KIBANA_USER" = "RUNASIS" ]; then
+    SUBIT=""
+else
+    SUBIT="$SU - $KIBANA_USER -s /bin/sh -c "
+fi
+
 start()
 {
     echo -n $"Starting $prog: "
-    nohup $DAEMON $DAEMON_ARGS </dev/null >/dev/null 2>&1 &
+    nohup $SUBIT $DAEMON $DAEMON_ARGS </dev/null >/dev/null 2>&1 &
     retval=$?
     if [ rh_status_q ]; then
         touch $lockfile

--- a/templates/kibana.yml.erb
+++ b/templates/kibana.yml.erb
@@ -4,6 +4,12 @@ port: <%= @port %>
 # The host to bind the server to.
 host: "<%= @host %>"
 
+# The location of log files:
+# log_file: ./kibana.log
+<% if @log_file -%>
+log_file: <%= @log_file %>
+<%- end -%>
+
 # The Elasticsearch instance to use for all your queries.
 elasticsearch_url: "<%= @elasticsearch_url %>"
 


### PR DESCRIPTION
Hi,

This PR changes the RedHat init script (I don't have a Debian machine available here to change the other) to allow the process to be run as a non-privileged user.

When actually doing so, you need to fix the log file and the pid file.
The second commit allows a separate log file, although no effort is spent handling its permissions (this can be done outside the module).
The pid file can already be altered using the 'pid_file' parameter, the same applies with the log file: ensure that the parent directory exists with the correct permissions.

By default no change is made, so the PR should be backwards-compatible.

Regards,
Steven
